### PR TITLE
Add fontFamily transform function support for css plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ var fontmin = new Fontmin()
     }));
 ```
 
+Alternatively, a transform function can be passed as `fontFamily` option.
+```js
+var Fontmin = require('fontmin');
+
+var fontmin = new Fontmin()
+    .use(Fontmin.css({
+        // ...
+        fontFamily: function(fontInfo, ttf) {
+          return "Transformed Font Family Name"
+        },
+        // ...
+    }));
+```
+
 ### .svg2ttf()
 
 Convert font format svg to ttf.

--- a/plugins/css.js
+++ b/plugins/css.js
@@ -75,13 +75,39 @@ function getGlyfList(ttf) {
 }
 
 /**
+ * get font family name
+ *
+ * @param {Object} font info object
+ * @param {ttfObject} ttf ttfObject
+ * @param {Object} opts opts
+ * @return {string} font family name
+ */
+function getFontFamily(fontInfo, ttf, opts) {
+    var fontFamily = opts.fontFamily;
+    // Call transform function
+    if (typeof fontFamily === 'function') {
+        fontFamily = fontFamily(_.cloneDeep(fontInfo), ttf);
+    }
+    return fontFamily || ttf.name.fontFamily || fontInfo.fontFile;
+}
+
+/**
+ * Transform font family name
+ * @callback FontFamilyTransform
+ * @param {Object} font info object
+ * @param {ttfObject} ttf ttfObject
+ * @return {string} font family name
+ */
+// function(fontInfo, ttfObject) { return "Font Name"; }
+
+/**
  * css fontmin plugin
  *
  * @param {Object} opts opts
  * @param {boolean=} opts.glyph     generate class for each glyph. default = false
  * @param {boolean=} opts.base64    inject base64
  * @param {string=} opts.iconPrefix icon prefix
- * @param {string=} opts.fontFamily fontFamily
+ * @param {(string|FontFamilyTransform)=} opts.fontFamily fontFamily
  * @return {Object} stream.Transform instance
  * @api public
  */
@@ -143,9 +169,7 @@ module.exports = function (opts) {
         }
 
         // font family
-        fontInfo.fontFamily = opts.fontFamily
-            || ttfObject.name.fontFamily
-            || fontFile;
+        fontInfo.fontFamily = getFontFamily(fontInfo, ttfObject, opts);
 
         // rewrite font family as filename
         if (opts.asFileName) {
@@ -180,4 +204,3 @@ module.exports = function (opts) {
     });
 
 };
-

--- a/test/font.js
+++ b/test/font.js
@@ -65,7 +65,10 @@ before(function (done) {
             glyph: true,
             base64: true,
             fontPath: './',
-            local: true
+            local: true,
+            fontFamily: function(font, ttf) {
+              return ttf.name.fontFamily + " - Transformed";  
+            }
         }))
         .dest(destPath);
 
@@ -287,6 +290,16 @@ describe('css plugin', function () {
         catch (ex) {
             assert(false);
         }
+    });
+
+    it('dest css should have transformed @font-family name', function() {
+        var content = fs.readFileSync(destFile + '.css', {
+            encoding: 'utf-8'
+        });
+        var m = content.match(/font-family: \s*"(.*?)"/),
+          fontFamily = m[1];
+        expect(fontFamily).to.be.a('string')
+          .that.match(/\s-\sTransformed$/);
     });
 
 


### PR DESCRIPTION
## Use case
The user wants to change `fontFamily` names in css for each font, when processing multiple fonts from different font families. 

## Example

The user wants to use short font names (right column) in CSS instead of very long names (left column):
> Font A With Very Looooooong Name -> A
> Font B With Very Looooooooooooooooong Name -> B 
> Font C With Very Looooooooooooooooooooooooooooong Name -> B 

```js
var fontmin = new Fontmin()
  .use(Fontmin.css({
    // Other options
    fontFamily: function(fontInfo, ttf) {
      return ttf.name.fontFamily.replace(/Font (\w+) With Very Lo*ng Name/, "$1");
    }
  }));
```
 
## Changes
* Support passing a transform function as css plugin's `opts.fontFamily` field
* Add a test case
* Update document