### PR TITLE
Fix css selector

### DIFF
--- a/lib/font-face.tpl
+++ b/lib/font-face.tpl
@@ -12,7 +12,7 @@
 
 <% if (glyph) { %>
 [class^="<%=iconPrefix%>-"],
-[class*=" <%=iconPrefix%>-"]:after {
+[class*=" <%=iconPrefix%>-"]:before {
     font-family: "<%=fontFamily%>";
     speak: none;
     font-style: normal;

--- a/lib/font-face.tpl
+++ b/lib/font-face.tpl
@@ -12,7 +12,7 @@
 
 <% if (glyph) { %>
 [class^="<%=iconPrefix%>-"],
-[class*=" <%=iconPrefix%>-"]:before {
+[class*=" <%=iconPrefix%>-"] {
     font-family: "<%=fontFamily%>";
     speak: none;
     font-style: normal;


### PR DESCRIPTION
Was ":after", will work better with ":before" (see https://github.com/ecomfe/fontmin/issues/37), but removing the selector entirely yields correct results as well, and is in fact more or less how [Glyphicon](getbootstrap.com/components/#glyphicons) works in Bootstrap.
