### PR TITLE
Work around bug in TTFReader subsetting loading

### DIFF
--- a/plugins/glyph.js
+++ b/plugins/glyph.js
@@ -84,7 +84,13 @@ function minifyTtf(contents, opts) {
     var ttfobj = contents;
 
     if (Buffer.isBuffer(contents)) {
+        // TTFReader sometimes return the wrong glyph for space
+        // work around it for now by loading the entire font
+        // and letting minifyFontObject do the work of minimizing the font
+        var subset = opts.subset;
+        opts.subset = [];
         ttfobj = new TTFReader(opts).read(b2ab(contents));
+        opts.subset = subset;
     }
 
     var miniObj = minifyFontObject(


### PR DESCRIPTION
Work around bug in TTFReader subsetting loading the wrong glyph for space.  To see this issue you need to pass the option trim: false

This is my work around to fix the second issue mentioned in the following issue when trim is false
https://github.com/ecomfe/fontmin/issues/43

It would probably be better to fix it in fonteditor-core, this work around causes it to load more then it needs to.
https://github.com/kekee000/fonteditor-core/issues/7
