### PR TITLE
为了兼容4字节unicode字符，charCodeAt改为codePointAt

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -102,8 +102,8 @@ function getSubsetText(opts) {
  * @return {Array}      unicodes
  */
 function string2unicodes(str) {
-    return str.split('').map(function (text) {
-        return text.charCodeAt(0);
+    return Array.from(str).map(function (text) {
+        return text.codePointAt(0);
     });
 }
 


### PR DESCRIPTION
str.split('') 会将4字节unicode字符拆成两个字符，改为Array.from(str)
text.charCodeAt(0) 只会识别4字节unicode字符的前两个字节，改为text.codePointAt(0)