### PR TITLE
Upgrade dependencies to fix warning in Node ≥ 14.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,26 +35,27 @@
   },
   "scripts": {
     "test": "mocha",
-    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec --check-leaks test/"
+    "coverage": "nyc mocha --reporter spec --check-leaks test/"
   },
   "dependencies": {
-    "b3b": "0.0.1",
+    "b3b": "^0.0.1",
     "buffer-to-vinyl": "^1.0.0",
     "code-points": "^2.0.0-1",
-    "concat-stream": "^1.6.2",
-    "fonteditor-core": "^1.0.2",
-    "get-stdin": "^6.0.0",
+    "concat-stream": "^2.0.0",
+    "fonteditor-core": "^2.1.5",
+    "get-stdin": "^8.0.0",
     "is-otf": "^0.1.2",
-    "is-svg": "^1.1.1",
+    "is-svg": "^4.2.1",
     "is-ttf": "^0.2.2",
     "lodash": "^4.17.10",
-    "meow": "^3.0.0",
-    "pako": "^1.0.1",
-    "replace-ext": "0.0.1",
+    "meow": "^9.0.0",
+    "nyc": "^15.1.0",
+    "pako": "^2.0.3",
+    "replace-ext": "^2.0.0",
     "stream-combiner": "^0.2.1",
-    "through2": "2.0.1",
-    "ttf2woff2": "3.0.0",
-    "vinyl-fs": "3.0.3"
+    "through2": "^4.0.2",
+    "ttf2woff2": "^4.0.1",
+    "vinyl-fs": "^3.0.3"
   },
   "devDependencies": {
     "chai": "^4.1.2",
@@ -62,7 +63,6 @@
     "is-eot": "^1.0.0",
     "is-woff": "^1.0.1",
     "is-woff2": "^1.0.0",
-    "istanbul": "^0.4.3",
-    "mocha": "^6.1.4"
+    "mocha": "^8.3.0"
   }
 }

--- a/plugins/svgs2ttf.js
+++ b/plugins/svgs2ttf.js
@@ -15,7 +15,7 @@ var bufferToVinyl = require('buffer-to-vinyl');
 var TTFWriter = require('fonteditor-core').TTFWriter;
 var TTF = require('fonteditor-core').TTF;
 var svg2ttfobject = require('fonteditor-core').svg2ttfobject;
-var getEmptyttfObject = require('fonteditor-core/ttf/getEmptyttfObject');
+var getEmptyttfObject = require('fonteditor-core/lib/ttf/getEmptyttfObject').default;
 
 /**
  * SvgFont

--- a/plugins/ttf2woff.js
+++ b/plugins/ttf2woff.js
@@ -19,7 +19,9 @@ function compileTtf(buffer, options, cb) {
     var ttf2woffOpts = {};
 
     if (options.deflate) {
-        ttf2woffOpts.deflate = deflate;
+        ttf2woffOpts.deflate = function (input) {
+            return deflate(Uint8Array.from(input));
+        };
     }
 
     try {


### PR DESCRIPTION
I replaced the [deprecated](https://www.npmjs.com/package/istanbul) istanbul package with nyc, and made the trivial fixes for upstream API changes in fonteditor-core and pako.

The ttf2woff2 upgrade in particular fixes a warning in Node ≥ 14.6.0: https://github.com/nfroidure/ttf2woff2/pull/62.