### PR TITLE
Fix unique glyph codes check in getSubsetText

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -107,7 +107,7 @@ function getSubsetText(opts) {
     // basicText
     opts.basicText && (text += basicText);
 
-    return getUniqText(text);
+    return text;
 }
 
 /**
@@ -117,7 +117,7 @@ function getSubsetText(opts) {
  * @return {Array}      unicodes
  */
 function string2unicodes(str) {
-    return codePoints(str);
+    return _.uniq(codePoints(str));
 }
 
 exports.getFontFolder = getFontFolder;


### PR DESCRIPTION
Don't use getUniqText() for glyphs subset, check for codes uniqueness in string2unicodes() instead.

getUniqueText() process passed string as a regular one. In some cases it doesn't handle unicode properly and will remove code points parts when several code points share the same numeric parts.

Ultimately, it will result in wrong code points being pushed to output.

In some cases, the glyphs count will match, not the codes themselves (tested and confirmed with FontAwesome's Duotone font variation).

Fix UTF-16 glyphs subset (and probably others), tested and confirmed with FontAwesome's Duotone font variation where glyphs code points look like this: \10f6ae (https://fontawesome.com/v5.15/icons/acorn?style=duotone).

_Keeping getUniqText() method for backward compatibility / third party packages relying on it._