### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ npm-debug.log
 node_modules
 fonts/dest*
 /coverage
-.nyc_output
 package-lock.json
 test/ts/example.js

--- a/cli.js
+++ b/cli.js
@@ -7,14 +7,13 @@
 
 /* eslint-env node */
 
-'use strict';
-
-var fs = require('fs');
-var meow = require('meow');
-var path = require('path');
-var stdin = require('get-stdin');
-var Fontmin = require('./');
-var _ = require('lodash');
+import * as fs from 'fs';
+import meow from 'meow';
+import * as path from 'path';
+import * as url from 'url';
+import stdin from 'get-stdin';
+import Fontmin from './index.js';
+import _ from 'lodash';
 
 var cli = meow({
     help: [
@@ -62,7 +61,8 @@ var cli = meow({
 
 // version
 if (cli.flags.version) {
-    console.log(require('./package.json').version);
+    var pkg = JSON.parse(fs.readFileSync(url.fileURLToPath(new URL('package.json', import.meta.url))));
+    console.log(pkg.version);
     process.exit(0);
 }
 

--- a/cli.js
+++ b/cli.js
@@ -10,12 +10,12 @@
 import * as fs from 'fs';
 import meow from 'meow';
 import * as path from 'path';
-import * as url from 'url';
 import stdin from 'get-stdin';
 import Fontmin from './index.js';
 import _ from 'lodash';
 
 var cli = meow({
+    importMeta: import.meta,
     help: [
         'Usage',
         '  $ fontmin <file> [<output>]',
@@ -36,35 +36,16 @@ var cli = meow({
         '  --font-family                       font-family for @font-face CSS',
         '  --css-glyph                         generate class for each glyf. default = false',
         '  -T, --show-time                     show time fontmin cost'
-    ].join('\n')
-}, {
-    'boolean': [
-        'basic-text',
-        'show-time',
-        'deflate-woff',
-        'css-glyph',
-        'version'
-    ],
-    'string': [
-        'text',
-        'font-family'
-    ],
-    'alias': {
-        t: 'text',
-        b: 'basic-text',
-        d: 'deflate-woff',
-        T: 'show-time',
-        h: 'help',
-        v: 'version'
-    }
+    ].join('\n'),
+    flags: {
+        basicText: { type: 'boolean', shortFlag: 'b' },
+        showTime: { type: 'boolean', shortFlag: 'T' },
+        deflateWoff: { type: 'boolean', shortFlag: 'd' },
+        cssGlyph: { type: 'boolean' },
+        text: { type: 'string', shortFlag: 't' },
+        fontFamily: { type: 'string' },
+    },
 });
-
-// version
-if (cli.flags.version) {
-    var pkg = JSON.parse(fs.readFileSync(url.fileURLToPath(new URL('package.json', import.meta.url))));
-    console.log(pkg.version);
-    process.exit(0);
-}
 
 function isFile(path) {
     if (/^[^\s]+\.\w*$/.test(path)) {

--- a/index.js
+++ b/index.js
@@ -163,7 +163,8 @@ Fontmin.prototype.getFiles = function () {
         return bufferToVinyl.stream(this._src[0]);
     }
 
-    return vfs.src.apply(vfs, this.src());
+    var [src, options] = this.src();
+    return vfs.src(src, {encoding: false, ...options});
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -5,12 +5,25 @@
 
 /* eslint-env node */
 
-var combine = require('stream-combiner');
-var concat = require('concat-stream');
-var EventEmitter = require('events').EventEmitter;
-var inherits = require('util').inherits;
-var bufferToVinyl = require('buffer-to-vinyl');
-var vfs = require('vinyl-fs');
+import combine from 'stream-combiner';
+import concat from 'concat-stream';
+import { EventEmitter } from 'events';
+import { inherits } from 'util';
+import * as bufferToVinyl from 'buffer-to-vinyl';
+import vfs from 'vinyl-fs';
+
+import * as util from './lib/util.js';
+import mime from './lib/mime-types.js';
+
+import glyph from './plugins/glyph.js';
+import ttf2eot from './plugins/ttf2eot.js';
+import ttf2woff from './plugins/ttf2woff.js';
+import ttf2woff2 from './plugins/ttf2woff2.js';
+import ttf2svg from './plugins/ttf2svg.js';
+import css from './plugins/css.js';
+import svg2ttf from './plugins/svg2ttf.js';
+import svgs2ttf from './plugins/svgs2ttf.js';
+import otf2ttf from './plugins/otf2ttf.js';
 
 /**
  * Initialize Fontmin
@@ -171,16 +184,21 @@ Fontmin.plugins = [
 ];
 
 // export pkged plugins
-Fontmin.plugins.forEach(function (plugin) {
-    Fontmin[plugin] = require('./plugins/' + plugin);
-});
+Fontmin.glyph = glyph;
+Fontmin.ttf2eot = ttf2eot;
+Fontmin.ttf2woff = ttf2woff;
+Fontmin.ttf2woff2 = ttf2woff2;
+Fontmin.ttf2svg = ttf2svg;
+Fontmin.css = css;
+Fontmin.svg2ttf = svg2ttf;
+Fontmin.svgs2ttf = svgs2ttf;
+Fontmin.otf2ttf = otf2ttf;
 
 /**
  * Module exports
  */
-module.exports = Fontmin;
 
-// exports util, mime
-module.exports.default = Fontmin;
-module.exports.util = exports.util = require('./lib/util');
-module.exports.mime = exports.mime = require('./lib/mime-types');
+export { util, mime };
+export default Fontmin;
+Fontmin.util = util;
+Fontmin.mime = mime;

--- a/lib/mime-types.js
+++ b/lib/mime-types.js
@@ -5,7 +5,7 @@
 
 /* eslint-env node */
 
-module.exports = exports = {
+export default {
     '.*': 'application/octet-stream',
     'ttf': 'application/font-sfnt',
     'otf': 'application/font-sfnt',

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,17 +5,17 @@
 
 /* eslint-env node */
 
-var fs = require('fs');
-var path = require('path');
-var _ = require('lodash');
-var codePoints = require('code-points');
+import * as fs from 'fs';
+import * as path from 'path';
+import _ from 'lodash';
+import codePoints from 'code-points';
 
 /**
  * getFontFolder
  *
  * @return {string} fontFolder
  */
-function getFontFolder() {
+export function getFontFolder() {
     return path.resolve({
         win32: '/Windows/fonts',
         darwin: '/Library/Fonts',
@@ -29,7 +29,7 @@ function getFontFolder() {
  * @param  {string} path path
  * @return {Array}      fonts
  */
-function getFonts() {
+export function getFonts() {
     return fs.readdirSync(getFontFolder());
 }
 
@@ -42,7 +42,7 @@ function getFonts() {
  * @param  {string} str target text
  * @return {string}     pure text
  */
-function getPureText(str) {
+export function getPureText(str) {
 
     // fix space
     var emptyTextMap = {};
@@ -77,7 +77,7 @@ function getPureText(str) {
  * @param  {string} str target text
  * @return {string}     uniq text
  */
-function getUniqText(str) {
+export function getUniqText(str) {
     return _.uniq(
         str.split('')
     ).join('');
@@ -99,7 +99,7 @@ var basicText = String.fromCharCode.apply(this, _.range(33, 126));
  * @param  {Object} opts opts
  * @return {string}      subset text
  */
-function getSubsetText(opts) {
+export function getSubsetText(opts) {
 
     var text = opts.text || '';
 
@@ -118,13 +118,6 @@ function getSubsetText(opts) {
  * @param  {string} str string
  * @return {Array}      unicodes
  */
-function string2unicodes(str) {
+export function string2unicodes(str) {
     return _.uniq(codePoints(str));
 }
-
-exports.getFontFolder = getFontFolder;
-exports.getFonts = getFonts;
-exports.getPureText = getPureText;
-exports.getUniqText = getUniqText;
-exports.getSubsetText = getSubsetText;
-exports.string2unicodes = string2unicodes;

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fonteditor-core": "^2.4.0",
     "get-stdin": "^8.0.0",
     "is-otf": "^0.1.2",
-    "is-svg": "^4.2.1",
+    "is-svg": "^5.1.0",
     "is-ttf": "^0.2.2",
     "lodash": "^4.17.10",
     "meow": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "test": "mocha test/*.spec.js",
-    "coverage": "nyc mocha --reporter spec --check-leaks test/*.spec.js"
+    "coverage": "c8 mocha --reporter spec --check-leaks test/*.spec.js"
   },
   "exports": {
     "require": "./index.js",
@@ -66,12 +66,12 @@
     "vinyl-fs": "^3.0.3"
   },
   "devDependencies": {
+    "c8": "^10.1.2",
     "chai": "^4.1.2",
     "gulp-clean": "^0.4.0",
     "is-eot": "^1.0.0",
     "is-woff": "^1.0.1",
     "is-woff2": "^1.0.0",
-    "mocha": "^9.1.1",
-    "nyc": "^15.1.0"
+    "mocha": "^9.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fontmin",
   "version": "1.1.0",
   "description": "Minify font seamlessly, font subsetter, webfont (eot, woff, svg) converter.",
+  "type": "module",
   "main": "index.js",
   "types": "index.d.ts",
   "keywords": [
@@ -31,7 +32,7 @@
   "license": "MIT",
   "repository": "ecomfe/fontmin",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "bin": {
     "fontmin": "cli.js"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "stream-combiner": "^0.2.1",
     "through2": "^4.0.2",
     "ttf2woff2": "^4.0.1",
-    "vinyl-fs": "^3.0.3"
+    "vinyl-fs": "^4.0.0"
   },
   "devDependencies": {
     "c8": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
     "import": "./index.js"
   },
   "dependencies": {
-    "@types/node": "^12.20.55",
+    "@types/node": "*",
     "@types/through2": "^2.0.38",
     "b3b": "^0.0.1",
     "buffer-to-vinyl": "^1.0.0",
     "code-points": "^2.0.0-1",
     "concat-stream": "^2.0.0",
     "fonteditor-core": "^2.4.0",
-    "get-stdin": "^8.0.0",
+    "get-stdin": "^9.0.0",
     "is-otf": "^0.1.2",
     "is-svg": "^5.1.0",
     "is-ttf": "^0.2.2",
@@ -63,16 +63,16 @@
     "replace-ext": "^2.0.0",
     "stream-combiner": "^0.2.1",
     "through2": "^4.0.2",
-    "ttf2woff2": "^4.0.1",
+    "ttf2woff2": "^6.0.1",
     "vinyl-fs": "^4.0.0"
   },
   "devDependencies": {
     "c8": "^10.1.2",
-    "chai": "^4.1.2",
+    "chai": "^5.1.2",
     "gulp-clean": "^0.4.0",
     "is-eot": "^1.0.0",
     "is-woff": "^1.0.1",
     "is-woff2": "^1.0.0",
-    "mocha": "^9.1.1"
+    "mocha": "^10.8.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "repository": "ecomfe/fontmin",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "bin": {
     "fontmin": "cli.js"
@@ -58,7 +58,7 @@
     "is-svg": "^5.1.0",
     "is-ttf": "^0.2.2",
     "lodash": "^4.17.10",
-    "meow": "^9.0.0",
+    "meow": "^13.2.0",
     "pako": "^2.0.3",
     "replace-ext": "^2.0.0",
     "stream-combiner": "^0.2.1",

--- a/plugins/css.js
+++ b/plugins/css.js
@@ -4,13 +4,14 @@
  */
 
 /* eslint-env node */
-var _ = require('lodash');
-var fs = require('fs');
-var path = require('path');
-var isTtf = require('is-ttf');
-var through = require('through2');
-var replaceExt = require('replace-ext');
-var b2a = require('b3b').b2a;
+import _ from 'lodash';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as url from 'url';
+import isTtf from 'is-ttf';
+import through from 'through2';
+import replaceExt from 'replace-ext';
+import { b2a } from 'b3b';
 
 /**
  * tpl
@@ -18,7 +19,7 @@ var b2a = require('b3b').b2a;
  * @type {string}
  */
 var tpl = fs.readFileSync(
-    path.resolve(__dirname, '../lib/font-face.tpl')
+    url.fileURLToPath(new URL('../lib/font-face.tpl', import.meta.url))
 ).toString('utf-8');
 
 /**
@@ -112,7 +113,7 @@ function getFontFamily(fontInfo, ttf, opts) {
  * @return {Object} stream.Transform instance
  * @api public
  */
-module.exports = function (opts) {
+export default function (opts) {
     opts = opts || {};
 
     return through.ctor({

--- a/plugins/glyph.js
+++ b/plugins/glyph.js
@@ -5,15 +5,12 @@
 
 /* eslint-env node */
 
-var _ = require('lodash');
-var isTtf = require('is-ttf');
-var through = require('through2');
-var TTF = require('fonteditor-core').TTF;
-var TTFReader = require('fonteditor-core').TTFReader;
-var TTFWriter = require('fonteditor-core').TTFWriter;
-var b2ab = require('b3b').b2ab;
-var ab2b = require('b3b').ab2b;
-var util = require('../lib/util');
+import _ from 'lodash';
+import isTtf from 'is-ttf';
+import through from 'through2';
+import fonteditorCore from 'fonteditor-core';
+import { b2ab, ab2b } from 'b3b';
+import * as util from '../lib/util.js';
 
 /**
  * getSubsetGlyfs
@@ -56,7 +53,7 @@ function minifyFontObject(ttfObject, subset, plugin) {
     }
 
     // new TTF Object
-    var ttf = new TTF(ttfObject);
+    var ttf = new fonteditorCore.TTF(ttfObject);
 
     // get target glyfs then set
     ttf.setGlyf(getSubsetGlyfs(ttf, subset));
@@ -84,7 +81,7 @@ function minifyTtf(contents, opts) {
     var ttfobj = contents;
 
     if (Buffer.isBuffer(contents)) {
-        ttfobj = new TTFReader(opts).read(b2ab(contents));
+        ttfobj = new fonteditorCore.TTFReader(opts).read(b2ab(contents));
     }
 
     var miniObj = minifyFontObject(
@@ -94,7 +91,7 @@ function minifyTtf(contents, opts) {
     );
 
     var ttfBuffer = ab2b(
-        new TTFWriter(Object.assign({writeZeroContoursGlyfData: true}, opts)).write(miniObj)
+        new fonteditorCore.TTFWriter(Object.assign({writeZeroContoursGlyfData: true}, opts)).write(miniObj)
     );
 
     return {
@@ -116,7 +113,7 @@ function minifyTtf(contents, opts) {
  * @return {Object} stream.Transform instance
  * @api public
  */
-module.exports = function (opts) {
+export default function (opts) {
 
     opts = _.extend({hinting: true, trim: true}, opts);
 

--- a/plugins/otf2ttf.js
+++ b/plugins/otf2ttf.js
@@ -5,15 +5,13 @@
 
 /* eslint-env node */
 
-var isOtf = require('is-otf');
-var through = require('through2');
-var otf2ttfobject = require('fonteditor-core').otf2ttfobject;
-var TTFWriter = require('fonteditor-core').TTFWriter;
-var b2ab = require('b3b').b2ab;
-var ab2b = require('b3b').ab2b;
-var replaceExt = require('replace-ext');
-var _ = require('lodash');
-var util = require('../lib/util');
+import isOtf from 'is-otf';
+import through from 'through2';
+import fonteditorCore from 'fonteditor-core';
+import { b2ab, ab2b } from 'b3b';
+import replaceExt from 'replace-ext';
+import _ from 'lodash';
+import * as util from '../lib/util.js';
 
 /**
  * otf2ttf fontmin plugin
@@ -22,7 +20,7 @@ var util = require('../lib/util');
  * @return {Object} stream.Transform instance
  * @api public
  */
-module.exports = function (opts) {
+export default function (opts) {
 
     opts = _.extend({clone: false, hinting: true}, opts);
 
@@ -67,9 +65,9 @@ module.exports = function (opts) {
         // try otf2ttf
         try {
 
-            ttfObj = otf2ttfobject(b2ab(file.contents), opts);
+            ttfObj = fonteditorCore.otf2ttfobject(b2ab(file.contents), opts);
 
-            ttfBuffer = ab2b(new TTFWriter(opts).write(ttfObj));
+            ttfBuffer = ab2b(new fonteditorCore.TTFWriter(opts).write(ttfObj));
 
         }
         catch (ex) {

--- a/plugins/svg2ttf.js
+++ b/plugins/svg2ttf.js
@@ -40,7 +40,7 @@ export default function (opts) {
         }
 
         // check svg
-        if (!isSvg(file.contents)) {
+        if (!isSvg(file.contents.toString())) {
             cb(null, file);
             return;
         }

--- a/plugins/svg2ttf.js
+++ b/plugins/svg2ttf.js
@@ -5,13 +5,12 @@
 
 /* eslint-env node */
 
-var isSvg = require('is-svg');
-var through = require('through2');
-var TTFWriter = require('fonteditor-core').TTFWriter;
-var svg2ttfobject = require('fonteditor-core').svg2ttfobject;
-var ab2b = require('b3b').ab2b;
-var replaceExt = require('replace-ext');
-var _ = require('lodash');
+import isSvg from 'is-svg';
+import through from 'through2';
+import fonteditorCore from 'fonteditor-core';
+import { ab2b } from 'b3b';
+import replaceExt from 'replace-ext';
+import _ from 'lodash';
 
 /**
  * svg2ttf fontmin plugin
@@ -20,7 +19,7 @@ var _ = require('lodash');
  * @return {Object} stream.Transform instance
  * @api public
  */
-module.exports = function (opts) {
+export default function (opts) {
 
     opts = _.extend({clone: true, hinting: true}, opts);
 
@@ -60,11 +59,11 @@ module.exports = function (opts) {
 
         try {
 
-            var ttfObj = svg2ttfobject(
+            var ttfObj = fonteditorCore.svg2ttfobject(
                 file.contents.toString('utf-8')
             );
 
-            output = ab2b(new TTFWriter(opts).write(ttfObj));
+            output = ab2b(new fonteditorCore.TTFWriter(opts).write(ttfObj));
 
         }
         catch (ex) {

--- a/plugins/svgs2ttf.js
+++ b/plugins/svgs2ttf.js
@@ -163,7 +163,7 @@ export default function (file, opts) {
         }
 
         // check svg
-        if (!isSvg(file.contents)) {
+        if (!isSvg(file.contents.toString())) {
             cb();
             return;
         }

--- a/plugins/svgs2ttf.js
+++ b/plugins/svgs2ttf.js
@@ -5,17 +5,15 @@
 
 /* eslint-env node */
 
-var isSvg = require('is-svg');
-var through = require('through2');
-var path = require('path');
-var replaceExt = require('replace-ext');
-var ab2b = require('b3b').ab2b;
-var _ = require('lodash');
-var bufferToVinyl = require('buffer-to-vinyl');
-var TTFWriter = require('fonteditor-core').TTFWriter;
-var TTF = require('fonteditor-core').TTF;
-var svg2ttfobject = require('fonteditor-core').svg2ttfobject;
-var getEmptyttfObject = require('fonteditor-core/lib/ttf/getEmptyttfObject').default;
+import isSvg from 'is-svg';
+import through from 'through2';
+import * as path from 'path';
+import replaceExt from 'replace-ext';
+import { ab2b } from 'b3b';
+import _ from 'lodash';
+import * as bufferToVinyl from 'buffer-to-vinyl';
+import fonteditorCore from 'fonteditor-core';
+import getEmptyttfObject from 'fonteditor-core/lib/ttf/getEmptyttfObject.js';
 
 /**
  * SvgFont
@@ -45,13 +43,13 @@ function SvgFont(name, opts) {
     );
 
     // empty ttfobj
-    var ttfobj = getEmptyttfObject();
+    var ttfobj = getEmptyttfObject.default();
 
     // for save name
     ttfobj.post.format = 2;
 
     // new TTF
-    this.ttf = new TTF(ttfobj);
+    this.ttf = new fonteditorCore.TTF(ttfobj);
 
     // set name
     this.ttf.setName(this.opts.name);
@@ -69,7 +67,7 @@ function SvgFont(name, opts) {
  */
 SvgFont.prototype.add = function (name, contents) {
 
-    var ttfObj = svg2ttfobject(
+    var ttfObj = fonteditorCore.svg2ttfobject(
         contents.toString('utf-8'),
         {
             combinePath: true
@@ -100,7 +98,7 @@ SvgFont.prototype.compile = function () {
     }
 
     this.contents = ab2b(
-        new TTFWriter(
+        new fonteditorCore.TTFWriter(
             this.opts
         )
         .write(
@@ -120,7 +118,7 @@ SvgFont.prototype.compile = function () {
  * @return {Object} stream.Transform instance
  * @api public
  */
-module.exports = function (file, opts) {
+export default function (file, opts) {
 
     if (!file) {
         throw new Error('Missing file option for fontmin-svg2ttf');

--- a/plugins/ttf2eot.js
+++ b/plugins/ttf2eot.js
@@ -5,18 +5,17 @@
 
 /* eslint-env node */
 
-var isTtf = require('is-ttf');
-var through = require('through2');
-var ttf2eot = require('fonteditor-core').ttf2eot;
-var b2ab = require('b3b').b2ab;
-var ab2b = require('b3b').ab2b;
-var replaceExt = require('replace-ext');
-var _ = require('lodash');
+import isTtf from 'is-ttf';
+import through from 'through2';
+import fonteditorCore from 'fonteditor-core';
+import { b2ab, ab2b } from 'b3b';
+import replaceExt from 'replace-ext';
+import _ from 'lodash';
 
 function compileTtf(buffer, cb) {
     var output;
     try {
-        output = ab2b(ttf2eot(b2ab(buffer)));
+        output = ab2b(fonteditorCore.ttf2eot(b2ab(buffer)));
     }
     catch (ex) {
         cb(ex);
@@ -33,7 +32,7 @@ function compileTtf(buffer, cb) {
  * @return {Object} stream.Transform instance
  * @api public
  */
-module.exports = function (opts) {
+export default function (opts) {
 
     opts = _.extend({clone: true}, opts);
 

--- a/plugins/ttf2svg.js
+++ b/plugins/ttf2svg.js
@@ -5,17 +5,17 @@
 
 /* eslint-env node */
 
-var isTtf = require('is-ttf');
-var through = require('through2');
-var ttf2svg = require('fonteditor-core').ttf2svg;
-var b2ab = require('b3b').b2ab;
-var replaceExt = require('replace-ext');
-var _ = require('lodash');
+import isTtf from 'is-ttf';
+import through from 'through2';
+import fonteditorCore from 'fonteditor-core';
+import { b2ab } from 'b3b';
+import replaceExt from 'replace-ext';
+import _ from 'lodash';
 
 function compileTtf(buffer, cb) {
     var output;
     try {
-        output = Buffer.from(ttf2svg(b2ab(buffer)));
+        output = Buffer.from(fonteditorCore.ttf2svg(b2ab(buffer)));
     }
     catch (ex) {
         cb(ex);
@@ -31,7 +31,7 @@ function compileTtf(buffer, cb) {
  * @return {Object} stream.Transform instance
  * @api public
  */
-module.exports = function (opts) {
+export default function (opts) {
 
     opts = _.extend({clone: true}, opts);
 

--- a/plugins/ttf2woff.js
+++ b/plugins/ttf2woff.js
@@ -5,14 +5,13 @@
 
 /* eslint-env node */
 
-var isTtf = require('is-ttf');
-var through = require('through2');
-var ttf2woff = require('fonteditor-core').ttf2woff;
-var b2ab = require('b3b').b2ab;
-var ab2b = require('b3b').ab2b;
-var replaceExt = require('replace-ext');
-var deflate = require('pako').deflate;
-var _ = require('lodash');
+import isTtf from 'is-ttf';
+import through from 'through2';
+import fonteditorCore from 'fonteditor-core';
+import { b2ab, ab2b } from 'b3b';
+import replaceExt from 'replace-ext';
+import { deflate } from 'pako';
+import _ from 'lodash';
 
 function compileTtf(buffer, options, cb) {
     var output;
@@ -27,7 +26,7 @@ function compileTtf(buffer, options, cb) {
     try {
         output = ab2b(
             // fix: have problem in some android device, close deflate
-            ttf2woff(
+            fonteditorCore.ttf2woff(
                 b2ab(buffer),
                 ttf2woffOpts
             )
@@ -47,7 +46,7 @@ function compileTtf(buffer, options, cb) {
  * @return {Object} stream.Transform instance
  * @api public
  */
-module.exports = function (opts) {
+export default function (opts) {
 
     opts = _.extend({clone: true}, opts);
 

--- a/plugins/ttf2woff2.js
+++ b/plugins/ttf2woff2.js
@@ -4,11 +4,11 @@
  */
 
 /* eslint-env node */
-var through = require('through2');
-var replaceExt = require('replace-ext');
-var _ = require('lodash');
-var ttf2woff2 = require('ttf2woff2');
-var isTtf = require('is-ttf');
+import through from 'through2';
+import replaceExt from 'replace-ext';
+import _ from 'lodash';
+import ttf2woff2 from 'ttf2woff2';
+import isTtf from 'is-ttf';
 
 /**
  * wawoff2 fontmin plugin
@@ -17,7 +17,7 @@ var isTtf = require('is-ttf');
  * @return {Object} stream.Transform instance
  * @api public
  */
-module.exports = function (opts) {
+export default function (opts) {
 
     opts = _.extend({clone: true}, opts);
 

--- a/test/base.spec.js
+++ b/test/base.spec.js
@@ -5,12 +5,11 @@
 
 /* eslint-env node */
 
-var expect = require('chai').expect;
-var path = require('path');
-var bufferToVinyl = require('buffer-to-vinyl');
-var Fontmin = require('../index');
+import { expect } from 'chai';
+import * as url from 'url';
+import Fontmin from '../index.js';
 var fm = Fontmin;
-var fontPath = path.resolve(__dirname, '../fonts');
+var fontPath = url.fileURLToPath(new URL('../fonts', import.meta.url));
 
 describe('Fontmin util', function () {
 

--- a/test/font.spec.js
+++ b/test/font.spec.js
@@ -245,7 +245,7 @@ describe('ttf2woff2 plugin', function () {
 describe('ttf2svg plugin', function () {
 
     it('output buffer should be svg', function () {
-        assert(isSvg(getFile(outputFiles, 'svg').contents));
+        assert(isSvg(getFile(outputFiles, 'svg').contents.toString()));
     });
 
     it('dest file should exist svg', function () {
@@ -258,7 +258,7 @@ describe('ttf2svg plugin', function () {
         try {
             assert(
                 isSvg(
-                    fs.readFileSync(destFile + '.svg')
+                    fs.readFileSync(destFile + '.svg', 'utf8')
                 )
             );
         }

--- a/test/font.spec.js
+++ b/test/font.spec.js
@@ -6,24 +6,24 @@
 /* eslint-env node */
 /* global before */
 
-var assert = require('chai').assert;
-var expect = require('chai').expect;
+import { assert, expect } from 'chai';
 
-var fs = require('fs');
-var path = require('path');
-var clean = require('gulp-clean');
-var isTtf = require('is-ttf');
-var isOtf = require('is-otf');
-var isEot = require('is-eot');
-var isWoff = require('is-woff');
-var isWoff2 = require('is-woff2');
-var isSvg = require('is-svg');
-var Fontmin = require('../index');
+import * as fs from 'fs';
+import * as path from 'path';
+import * as url from 'url';
+import clean from 'gulp-clean';
+import isTtf from 'is-ttf';
+import isOtf from 'is-otf';
+import isEot from 'is-eot';
+import isWoff from 'is-woff';
+import isWoff2 from 'is-woff2';
+import isSvg from 'is-svg';
+import Fontmin from '../index.js';
 
 
 var fontName = 'TpldKhangXiDictTrial';
-var srcPath = path.resolve(__dirname, '../fonts/' + fontName + '.otf');
-var destPath = path.resolve(__dirname, '../fonts/dest');
+var srcPath = url.fileURLToPath(new URL('../fonts/' + fontName + '.otf', import.meta.url));
+var destPath = url.fileURLToPath(new URL('../fonts/dest', import.meta.url));
 var destFile = path.resolve(destPath, fontName);
 
 var text = ''

--- a/test/subset.spec.js
+++ b/test/subset.spec.js
@@ -6,19 +6,21 @@
 /* eslint-env node */
 /* global before */
 
-var expect = require('chai').expect;
+import { expect } from 'chai';
 
-var fs = require('fs');
-var path = require('path');
-var clean = require('gulp-clean');
-var isTtf = require('is-ttf');
-var Fontmin = require('../index');
+import * as fs from 'fs';
+import path from 'path';
+import * as url from 'url';
+import clean from 'gulp-clean';
+import isTtf from 'is-ttf';
+import Fontmin from '../index.js';
+import fonteditorCore from 'fonteditor-core';
+import { b2ab } from 'b3b';
 
 var fontName = 'SentyBrush';
-var fontDir = path.resolve(__dirname, '../fonts');
+var fontDir = url.fileURLToPath(new URL('../fonts', import.meta.url));
 var srcPath = path.resolve(fontDir, fontName + '.ttf');
 var destPath = path.resolve(fontDir, 'dest_ttf');
-var {Font} = require('fonteditor-core');
 // first mined ttf
 var mined;
 
@@ -85,9 +87,7 @@ describe('subset', function () {
 
     // it('should has whitespace when trim false', function () {
 
-    //     var TTFReader = require('fonteditor-core').TTFReader;
-    //     var b2ab = require('b3b').b2ab;
-    //     var ttf = new TTFReader().read(b2ab(mined));
+    //     var ttf = new fonteditorCore.TTFReader().read(b2ab(mined));
 
     //     // contain whitespace
     //     expect(ttf.cmap).to.contain.any.keys(['32', '160', '202']);
@@ -96,9 +96,7 @@ describe('subset', function () {
 
     it('should has whitespace when mixed text and whitespace', function () {
 
-        var TTFReader = require('fonteditor-core').TTFReader;
-        var b2ab = require('b3b').b2ab;
-        var ttf = new TTFReader().read(b2ab(mined));
+        var ttf = new fonteditorCore.TTFReader().read(b2ab(mined));
 
         // contain whitespace
         expect(ttf.cmap).to.contain.any.keys(['32']);
@@ -193,7 +191,7 @@ describe('subset', function () {
             // it ttf
             expect(isTtf(twiceMined)).to.be.ok;
 
-            var font = Font.create(twiceMined, {type: 'ttf'});
+            var font = fonteditorCore.Font.create(twiceMined, {type: 'ttf'});
             expect(font.get().glyf.length).to.be.eq(5, 'glyf length');
             done();
         });
@@ -215,7 +213,7 @@ describe('subset', function () {
             // it ttf
             expect(isTtf(twiceMined)).to.be.ok;
 
-            var font = Font.create(twiceMined, {type: 'ttf'});
+            var font = fonteditorCore.Font.create(twiceMined, {type: 'ttf'});
             expect(font.get().glyf.length).to.be.eq(7, 'glyf length');
             expect(font.get().glyf.some(g => g.unicode && g.unicode.includes(0x3000))).to.be.ok;
             expect(font.get().glyf.some(g => g.unicode && g.unicode.includes(0x20))).to.be.ok;

--- a/test/svg2ttf.spec.js
+++ b/test/svg2ttf.spec.js
@@ -6,16 +6,17 @@
 /* eslint-env node */
 /* global before */
 
-var assert = require('chai').assert;
+import { assert } from 'chai';
 
-var fs = require('fs');
-var path = require('path');
-var clean = require('gulp-clean');
-var isTtf = require('is-ttf');
-var Fontmin = require('../index');
+import * as fs from 'fs';
+import * as path from 'path';
+import * as url from 'url';
+import clean from 'gulp-clean';
+import isTtf from 'is-ttf';
+import Fontmin from '../index.js';
 
-var srcPath = path.resolve(__dirname, '../fonts/fontawesome-webfont.svg');
-var destPath = path.resolve(__dirname, '../fonts/dest_svg');
+var srcPath = url.fileURLToPath(new URL('../fonts/fontawesome-webfont.svg', import.meta.url));
+var destPath = url.fileURLToPath(new URL('../fonts/dest_svg', import.meta.url));
 var destFile = destPath + '/fontawesome-webfont';
 
 function getFile(files, ext) {
@@ -66,7 +67,7 @@ describe('svg2ttf plugin', function () {
     it('input is\'t svg shoud be pass', function (done) {
 
         new Fontmin()
-            .src(path.resolve(__dirname, '../fonts/*.html'))
+            .src(url.fileURLToPath(new URL('../fonts/*.html', import.meta.url)))
             .use(Fontmin.svg2ttf())
             .run(function (err, files) {
                 var ext = path.extname(files[0].path);

--- a/test/svgs2ttf.spec.js
+++ b/test/svgs2ttf.spec.js
@@ -6,16 +6,16 @@
 /* eslint-env node */
 /* global before */
 
-var assert = require('chai').assert;
+import { assert } from 'chai';
 
-var fs = require('fs');
-var path = require('path');
-var clean = require('gulp-clean');
-var isTtf = require('is-ttf');
-var Fontmin = require('../index');
+import * as fs from 'fs';
+import * as url from 'url';
+import clean from 'gulp-clean';
+import isTtf from 'is-ttf';
+import Fontmin from '../index.js';
 
-var srcPath = path.resolve(__dirname, '../fonts/svg/*.svg');
-var destPath = path.resolve(__dirname, '../fonts/dest_svgs');
+var srcPath = url.fileURLToPath(new URL('../fonts/svg/*.svg', import.meta.url));
+var destPath = url.fileURLToPath(new URL('../fonts/dest_svgs', import.meta.url));
 var destFile = destPath + '/iconfont';
 
 
@@ -93,7 +93,7 @@ describe('svgs2ttf plugin', function () {
     it('input is\'t svg shoud be exclude', function (done) {
 
         new Fontmin()
-            .src(path.resolve(__dirname, '../fonts/*.html'))
+            .src(url.fileURLToPath(new URL('../fonts/*.html', import.meta.url)))
             .use(Fontmin.svgs2ttf('test.ttf'))
             .run(function (err, files) {
                 assert.equal(files.length, 0);


### PR DESCRIPTION
Many of our dependencies have switched to ES modules: get-stdin, is-svg, meow, ttf2woff2, chai. So we need to convert to ES modules to let us keep upgrading them.